### PR TITLE
user more user-friendly hourCycle for Tested at message

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -25,7 +25,7 @@ function checkEnvVar(variable) {
 }
 
 function generateCurrentTime() {
-    return new Date().toLocaleTimeString([], {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h24'});
+    return new Date().toLocaleTimeString([], {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23'});
 }
 
 function generateTimestamp() {


### PR DESCRIPTION
Close #9 

When people run `/lighthouse {url}` between 00:00:01 ~ 00:59:59 on 03/12/2021, the slack message could be

> Test started at: 03/12/2021, 24:00:01 ~ 24:59:59

After fix, it can be

> Test started at: 03/12/2021, 00:00:01 ~ 00:59:59