### PR TITLE
removes characters that don't match url

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -19,7 +19,15 @@ router.post('/lighthouse', async function(req, res) {
         trigger_id,
     } = req_data;
 
-    const req_options = text.split(' ');
+    let retext;
+    const onlyUrl = text.match(/(https?:\/\/[^ ]*)\b/);
+    if (onlyUrl) {
+        retext = onlyUrl[1];
+    } else { 
+        retext = text;
+    }
+
+    const req_options = retext.split(' ');
     const url_pattern = /^https?:\/\//;
     switch(req_options[0]) {
         case 'help':


### PR DESCRIPTION
When entering the following command
`/lighthouse {url}`

sometimes unintentionally mismatched characters like `<, >` were passed into the payload. 

FYI: I tested on pm2 local server


<img width="772" alt="스크린샷 2021-03-11 오후 11 48 01" src="https://user-images.githubusercontent.com/22214150/110889531-a6341780-8331-11eb-9748-815e2194498b.png">
