### PR TITLE
Improving Dockerfile caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+architecture.svg
+ecosystem.config.js

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,10 +9,6 @@ jobs:
     name: Build Lighthouse Image
     runs-on: ubuntu-18.04
 
-    strategy:
-      matrix:
-        node-version: [15.x]
-
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,14 @@ RUN  apt-get update \
      && wget --quiet https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O /usr/sbin/wait-for-it.sh \
      && chmod +x /usr/sbin/wait-for-it.sh
 
-COPY . /home/app
 WORKDIR /home/app
 
-RUN npm install
-RUN npm install -g pm2
+COPY ./package.json /home/app/package.json
+COPY ./yarn.lock /home/app/yarn.lock
+
+RUN yarn --frozen-lockfile
+RUN yarn global add pm2
+
+COPY . /home/app
+
 CMD [ "node", "src/index.js" ]


### PR DESCRIPTION
- Making use of yarn and yarn.lock
- Moving COPY directory command to be the last (ensuring it wont cause "yarn install" to re-run)
- Adding .dockerignore to prevent node_modules from being carried into build context